### PR TITLE
Feature/jetpack compose tabs upgrade kotlin 2

### DIFF
--- a/JetpackComposeTabs/app/build.gradle
+++ b/JetpackComposeTabs/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
 }
 
 android {
@@ -35,9 +36,7 @@ android {
     buildFeatures {
         compose true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion compose_version
-    }
+
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
@@ -47,18 +46,21 @@ android {
 }
 
 dependencies {
-        implementation(libs.androidx.core.ktx)
-        implementation(libs.compose.ui)
-        implementation(libs.compose.material)
-        implementation(libs.compose.ui.tooling.preview)
-        implementation(libs.lifecycle.runtime.ktx)
-        implementation(libs.activity.compose.lib) // alias from catalog
-        implementation(libs.compose.runtime.livedata)
+    implementation platform(libs.compose.bom)
 
-        testImplementation(libs.junit4)
-        androidTestImplementation(libs.androidx.test.junit)
-        androidTestImplementation(libs.espresso.core)
-        androidTestImplementation(libs.compose.ui.test.junit4)
-        debugImplementation(libs.compose.ui.tooling)
-        debugImplementation(libs.compose.ui.test.manifest)
+    implementation libs.androidx.core.ktx
+    implementation libs.compose.ui
+    implementation libs.compose.material
+    implementation libs.compose.ui.tooling.preview
+    implementation libs.lifecycle.runtime.ktx
+    implementation libs.activity.compose.lib
+    implementation libs.compose.runtime.livedata
+
+    testImplementation libs.junit4
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.espresso.core
+    androidTestImplementation libs.compose.ui.test.junit4
+
+    debugImplementation libs.compose.ui.tooling
+    debugImplementation libs.compose.ui.test.manifest
 }

--- a/JetpackComposeTabs/app/build.gradle
+++ b/JetpackComposeTabs/app/build.gradle
@@ -43,6 +43,7 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    namespace 'com.tomerpacific.jetpackcomposetabs'
 }
 
 dependencies {

--- a/JetpackComposeTabs/app/build.gradle
+++ b/JetpackComposeTabs/app/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation libs.lifecycle.runtime.ktx
     implementation libs.activity.compose.lib
     implementation libs.compose.runtime.livedata
+    implementation libs.compose.material.icons.extended
 
     testImplementation libs.junit4
     androidTestImplementation libs.androidx.test.junit

--- a/JetpackComposeTabs/app/build.gradle
+++ b/JetpackComposeTabs/app/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.tomerpacific.jetpackcomposetabs"
         minSdk 21
-        targetSdk 32
+        targetSdk 36
         versionCode 1
         versionName "1.0"
 

--- a/JetpackComposeTabs/app/build.gradle
+++ b/JetpackComposeTabs/app/build.gradle
@@ -47,18 +47,18 @@ android {
 }
 
 dependencies {
+        implementation(libs.androidx.core.ktx)
+        implementation(libs.compose.ui)
+        implementation(libs.compose.material)
+        implementation(libs.compose.ui.tooling.preview)
+        implementation(libs.lifecycle.runtime.ktx)
+        implementation(libs.activity.compose.lib) // alias from catalog
+        implementation(libs.compose.runtime.livedata)
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.3.1'
-    implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+        testImplementation(libs.junit4)
+        androidTestImplementation(libs.androidx.test.junit)
+        androidTestImplementation(libs.espresso.core)
+        androidTestImplementation(libs.compose.ui.test.junit4)
+        debugImplementation(libs.compose.ui.tooling)
+        debugImplementation(libs.compose.ui.test.manifest)
 }

--- a/JetpackComposeTabs/app/src/main/AndroidManifest.xml
+++ b/JetpackComposeTabs/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.tomerpacific.jetpackcomposetabs">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"

--- a/JetpackComposeTabs/app/src/main/java/com/tomerpacific/jetpackcomposetabs/ui/view/TabLayout.kt
+++ b/JetpackComposeTabs/app/src/main/java/com/tomerpacific/jetpackcomposetabs/ui/view/TabLayout.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier

--- a/JetpackComposeTabs/build.gradle
+++ b/JetpackComposeTabs/build.gradle
@@ -4,9 +4,9 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.2.1' apply false
-    id 'com.android.library' version '7.2.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.5.31' apply false
+    id 'com.android.application' version '8.9.1' apply false
+    id 'com.android.library' version '8.9.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
 }
 
 task clean(type: Delete) {

--- a/JetpackComposeTabs/build.gradle
+++ b/JetpackComposeTabs/build.gradle
@@ -1,12 +1,11 @@
 buildscript {
     ext {
-        compose_version = '1.1.0-beta01'
+        compose_version = '1.5.3'
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.9.1' apply false
-    id 'com.android.library' version '8.9.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
 }
 
 task clean(type: Delete) {

--- a/JetpackComposeTabs/gradle.properties
+++ b/JetpackComposeTabs/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false

--- a/JetpackComposeTabs/gradle/libs.versions.toml
+++ b/JetpackComposeTabs/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-mani
 
 lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle-runtime" }
 activity-compose-lib = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
+compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 
 # Testing
 junit4 = { group = "junit", name = "junit", version.ref = "junit" }

--- a/JetpackComposeTabs/gradle/libs.versions.toml
+++ b/JetpackComposeTabs/gradle/libs.versions.toml
@@ -1,0 +1,34 @@
+
+[versions]
+core-ktx = "1.7.0"
+compose = "1.1.0-beta01"
+lifecycle-runtime = "2.3.1"
+activity-compose = "1.3.1"
+junit = "4.13.2"
+androidx-junit = "1.1.5"
+espresso = "3.5.1"
+
+[libraries]
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
+
+# Compose
+compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
+compose-material = { group = "androidx.compose.material", name = "material", version.ref = "compose" }
+compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "compose" }
+compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "compose" }
+compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "compose" }
+compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose" }
+compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "compose" }
+
+lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle-runtime" }
+activity-compose-lib = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
+
+# Testing
+junit4 = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-junit" }
+espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
+
+[bundles]
+compose-all = [ "compose-ui", "compose-material", "compose-ui-tooling-preview", "compose-runtime-livedata" ]
+compose-debug = [ "compose-ui-tooling", "compose-ui-test-manifest" ]
+testing = [ "junit4", "androidx-test-junit", "espresso-core" ]

--- a/JetpackComposeTabs/gradle/libs.versions.toml
+++ b/JetpackComposeTabs/gradle/libs.versions.toml
@@ -1,9 +1,8 @@
-
 [versions]
 core-ktx = "1.7.0"
-compose = "1.1.0-beta01"
+compose-bom = "2024.11.00"
 android-gradle-plugin = "8.9.1"
-kotlin = "1.6.21"
+kotlin = "2.0.0"
 lifecycle-runtime = "2.3.1"
 activity-compose = "1.3.1"
 junit = "4.13.2"
@@ -13,14 +12,15 @@ espresso = "3.5.1"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 
-# Compose
-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
-compose-material = { group = "androidx.compose.material", name = "material", version.ref = "compose" }
-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "compose" }
-compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "compose" }
-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "compose" }
-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose" }
-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "compose" }
+# Compose via BOM
+compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+compose-ui = { group = "androidx.compose.ui", name = "ui" }
+compose-material = { group = "androidx.compose.material", name = "material" }
+compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata" }
+compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 
 lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle-runtime" }
 activity-compose-lib = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
@@ -39,3 +39,4 @@ testing = [ "junit4", "androidx-test-junit", "espresso-core" ]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/JetpackComposeTabs/gradle/libs.versions.toml
+++ b/JetpackComposeTabs/gradle/libs.versions.toml
@@ -2,6 +2,8 @@
 [versions]
 core-ktx = "1.7.0"
 compose = "1.1.0-beta01"
+android-gradle-plugin = "8.9.1"
+kotlin = "1.6.21"
 lifecycle-runtime = "2.3.1"
 activity-compose = "1.3.1"
 junit = "4.13.2"
@@ -32,3 +34,8 @@ espresso-core = { group = "androidx.test.espresso", name = "espresso-core", vers
 compose-all = [ "compose-ui", "compose-material", "compose-ui-tooling-preview", "compose-runtime-livedata" ]
 compose-debug = [ "compose-ui-tooling", "compose-ui-test-manifest" ]
 testing = [ "junit4", "androidx-test-junit", "espresso-core" ]
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
+android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/JetpackComposeTabs/gradle/wrapper/gradle-wrapper.properties
+++ b/JetpackComposeTabs/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Feb 19 20:12:50 IST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/JetpackComposeTabs/settings.gradle
+++ b/JetpackComposeTabs/settings.gradle
@@ -4,6 +4,14 @@ pluginManagement {
         google()
         mavenCentral()
     }
+
+    plugins {
+        id 'org.jetbrains.kotlin.android' version '2.0.0'          
+        id 'org.jetbrains.kotlin.plugin.compose' version '2.0.0'
+        id 'com.android.application' version '8.9.1'
+        id 'com.android.library' version '8.9.1'
+    }
+    
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
Resolves #69 

This pull request modernizes the project's build configuration for Jetpack Compose by updating Gradle, plugin, and dependency versions, and by switching to version catalogs for dependency management. It also introduces several improvements to build consistency and maintainability.

**Build System and Plugin Upgrades:**

* Updated Gradle wrapper to version `8.11.1` for compatibility with the latest Android tools.
* Upgraded Android Gradle Plugin and Kotlin plugin versions in `settings.gradle` and switched to alias-based plugin declarations in `build.gradle`.

**Dependency Management Improvements:**

* Migrated dependency declarations in `app/build.gradle` to use version catalogs (`libs.versions.toml`), simplifying updates and ensuring consistency. 
* Added a centralized `libs.versions.toml` file to manage versions and bundles for all dependencies and plugins.

**Android and Compose Configuration Updates:**

* Increased `compileSdk` and `targetSdk` to 36, and updated Compose version to `1.5.3` for improved compatibility and access to new features. 
* Added `org.jetbrains.kotlin.plugin.compose` to the plugins block and specified the namespace in `app/build.gradle`.

**Miscellaneous Enhancements:**

* Updated `gradle.properties` with new build feature flags for resource handling and build config generation.
* Minor cleanup in `AndroidManifest.xml` to remove redundant package declaration.